### PR TITLE
Clarify initialize in class definition structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1596,8 +1596,16 @@ at all.
       # followed by other macros (if any)
       validates :name
 
-      # public class methods are next in line
+      # initialize is next in line
+      def initialize
+      end
+
+      # followed by public class methods
       def self.some_method
+      end
+
+      # followed by initialize
+      def initialize
       end
 
       # followed by public instance methods


### PR DESCRIPTION
The `initialize` method is a particular anomaly in its behavior and definition. A strange and ambiguous characteristic is that it is defined as an instance method named `initialize` but is called as a *Class* method named `new`. 

For now, I have placed `initialize` as the first method to appear since it would appear in random places if it were to be placed alphabetically or after class methods. If anything, I would like this pull request to serve as a conversation starter.

That said, I am not particularly tied to placing it there and will modify the order if alternatives are preferred.
