### PR TITLE
Classes: use attributes directly instead of call accessors methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2278,6 +2278,28 @@ condition](#safe-assignment-in-condition).
   attr_reader :one, :two, :three
   ```
 
+* <a name="direct-attrs"></a>
+  Use attributes directly instead of call accessors methods.
+<sup>[[link](#direct-attrs)]</sup>
+
+  ```Ruby
+  class Robot
+    attr_reader :name
+
+    # some methods omitted
+
+    # bad
+    def hello
+      "Hello, my name is #{name}."
+    end
+
+    # good
+    def hi
+      "Hi, my name is #{@name}."
+    end
+  end
+  ```
+
 * <a name="struct-new"></a>
   Consider using `Struct.new`, which defines the trivial accessors,
   constructor and comparison operators for you.


### PR DESCRIPTION
Hello!

I added a few rules for use of `attr` family methods inside a class definition.

In example `name` is equivalent of `self.name` and this is a complete method call.

`@name` is more readable, and faster in use.

You can simple test it something like this:

``` ruby
class TestClass
  attr_reader :name

  def initialize
    @name = 'test_name'
  end

  def test1
    t = Time.now
    100_000_000.times{ @name }
    Time.now - t
  end

  def test2
    t = Time.now
    100_000_000.times{ name }
    Time.now - t
  end
end

x = TestClass.new
puts x.test1
puts x.test2
```

Moreover you can never shade `@name` of a some local variable. :smirk:

**UPD**: see improved test [below](https://github.com/bbatsov/ruby-style-guide/pull/310#issuecomment-40653771).
