### PR TITLE
Fix comment indent specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1981,7 +1981,7 @@ Translations of the guide are available in the following languages:
 
 * <a name="indent-annotations"></a>
   If multiple lines are required to describe the problem, subsequent lines
-  should be indented two spaces after the `#`.
+  should be indented three spaces after the `#`.
 <sup>[[link](#indent-annotations)]</sup>
 
   ```Ruby


### PR DESCRIPTION
The specification for multi-line comments said to indent two spaces after the '#', but the example shoed three spaces. I fixed the specification to be consistent with the example.

Fixes Issue #352.