### PR TITLE
Use double intent when continuing a line

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,11 +472,11 @@ Translations of the guide are available in the following languages:
     ```Ruby
     # bad - need to consult first line to understand second line
     one.two.three.
-      four
+        four
 
     # good - it's immediately clear what's going on the second line
     one.two.three
-      .four
+        .four
     ```
 
   * **(Option B)** When continuing a chained method invocation on another line,
@@ -486,11 +486,11 @@ Translations of the guide are available in the following languages:
     ```Ruby
     # bad - need to read ahead to the second line to know that the chain continues
     one.two.three
-      .four
+        .four
 
     # good - it's immediately clear that the expression continues beyond the first line
     one.two.three.
-      four
+        four
     ```
 
   A discussion on the merits of both alternative styles can be found


### PR DESCRIPTION
When continuing a line onto a second, I find it helpful to use a double indent so as to distinguish it from a normal start of a block.