### PR TITLE
change no-metaprogramming-masturbation to no-needless-metaprogramming

### DIFF
--- a/README.md
+++ b/README.md
@@ -3342,9 +3342,9 @@ condition](#safe-assignment-in-condition).
 
 ## Metaprogramming
 
-* <a name="no-metaprogramming-masturbation"></a>
+* <a name="no-needless-metaprogramming"></a>
   Avoid needless metaprogramming.
-<sup>[[link](#no-metaprogramming-masturbation)]</sup>
+<sup>[[link](#no-needless-metaprogramming)]</sup>
 
 * <a name="no-monkey-patching"></a>
   Do not mess around in core classes when writing libraries.  (Do not


### PR DESCRIPTION
In the interest of being more professional, I thought it would be nice to change this link from "no-metaprogramming-masturbation" to something else. I'd be open to suggestions other than "no-metaprogramming-masturbation".