### PR TITLE
Use Regexp.last_match(n) instead of Regexp.last_match[n]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3177,7 +3177,7 @@ condition](#safe-assignment-in-condition).
 
 * <a name="no-perl-regexp-last-matchers"></a>
   Don't use the cryptic Perl-legacy variables denoting last regexp group
-  matches (`$1`, `$2`, etc). Use `Regexp.last_match[n]` instead.
+  matches (`$1`, `$2`, etc). Use `Regexp.last_match(n)` instead.
 <sup>[[link](#no-perl-regexp-last-matchers)]</sup>
 
   ```Ruby
@@ -3188,7 +3188,7 @@ condition](#safe-assignment-in-condition).
   process $1
 
   # good
-  process Regexp.last_match[1]
+  process Regexp.last_match(1)
   ```
 
 * <a name="no-numbered-regexes"></a>
@@ -3200,7 +3200,7 @@ condition](#safe-assignment-in-condition).
   # bad
   /(regexp)/ =~ string
   ...
-  process Regexp.last_match[1]
+  process Regexp.last_match(1)
 
   # good
   /(?<meaningful_var>regexp)/ =~ string

--- a/README.md
+++ b/README.md
@@ -2975,6 +2975,42 @@ condition](#safe-assignment-in-condition).
   Do not modify a collection while traversing it.
 <sup>[[link](#no-modifying-collections)]</sup>
 
+* <a name="acessing-elements-directly"></a>
+  When accessing elements of a collection, avoid direct access
+  via `[n]` by using an alternate form of the reader method if it is
+  supplied. This guards you from calling `[]` on `nil`.
+<sup>[[link](#accessing-elements-directly)]</sup>
+
+  ```Ruby
+  # bad
+  Regexp.last_match[1]
+
+  # good
+  Regexp.last_match(1)
+  ```
+
+* <a name="provide-alternate-accessor-to-collections"></a>
+  When providing an accessor for a collection, provide an alternate form
+  to save users from checking for `nil` before accessing an element in
+  the collection.
+<sup>[[link](#provide-alternate-accessor-to_collections")]</sup>
+
+  ```Ruby
+  # bad
+  def awesome_things
+    @awesome_things
+  end
+
+  # good
+  def awesome_things(index = nil)
+    if index && @awesome_things
+      @awesome_things[index]
+    else
+      @awesome_things
+    end
+  end
+  ```
+
 ## Strings
 
 * <a name="string-interpolation"></a>


### PR DESCRIPTION
This form behaves the same as the Perl-like regex match variables by gracefully handling nil matches.

See bbatsov/rubocop/pull/1634 for more context.