### PR TITLE
Change the regex percent Literals to conform to style

### DIFF
--- a/README.md
+++ b/README.md
@@ -3345,11 +3345,11 @@ resource cleanup when possible.
 
   ```Ruby
   # bad
-  %r(\s+)
+  %r{\s+}
 
   # good
-  %r(^/(.*)$)
-  %r(^/blog/2011/(.*)$)
+  %r{^/(.*)$}
+  %r{^/blog/2011/(.*)$}
   ```
 
 * <a name="percent-x"></a>


### PR DESCRIPTION
The "good" example explaining when to use the percent literals syntax for regex uses `()` delimiters, while a few lines later the guide states that we should use `{}` delimiters instead.

I have changed this example to conform to the style guide.

Thanks,
Louis