### PR TITLE
Improve attribute macro usage in class consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2069,10 +2069,7 @@ condition](#safe-assignment-in-condition).
 
     # constants are next
     SOME_CONSTANT = 20
-
-    # afterwards we have attribute macros
-    attr_reader :name
-
+    
     # followed by other macros (if any)
     validates :name
 
@@ -2083,6 +2080,9 @@ condition](#safe-assignment-in-condition).
     # followed by public instance methods
     def some_method
     end
+    
+    # finishing off with public attribute macros
+    attr_reader :public_attribute
 
     # protected and private methods are grouped near the end
     protected
@@ -2094,6 +2094,9 @@ condition](#safe-assignment-in-condition).
 
     def some_private_method
     end
+    
+    # finally we have private attribute macros
+    attr_reader :private_attribute
   end
   ```
 


### PR DESCRIPTION
- Recognise that attribute macros may be used in private section
- Move attribute macros to the end of a section

I think the first point is relatively uncontroversial.

The second is effectively a breaking change, at least for the use of attribute macros in the public section. Attribute macros are better off a the bottom of sections for two reasons:
1. Their behaviour is trivial and uninteresting, moving them to the bottom of the section keeps them out of the way of more interesting code.
2. It avoids the potential for accidentally leaving redundant attribute macros which get over-ridden by subsequent methods defined on the class
