### PR TITLE
Fix inconsistency for an array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,7 +1114,7 @@ condition](#safe-assignment-in-condition).
 <sup>[[link](#single-line-blocks)]</sup>
 
   ```Ruby
-  names = ['Bozhidar', 'Steve', 'Sarah']
+  names = %w(Bozhidar Steve Sarah)
 
   # bad
   names.each do |name|


### PR DESCRIPTION
Fix an example of single-line blocks rule.

Replace an array of strings with literal syntax `%w()` to match [this rule](https://github.com/bbatsov/ruby-style-guide#percent-w)