### PR TITLE
Add initialize to consistent class structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2095,7 +2095,11 @@ condition](#safe-assignment-in-condition).
     def self.some_method
     end
 
-    # followed by public instance methods
+    # initialization goes between class methods and other instance methods
+    def initialize
+    end
+
+    # followed by other public instance methods
     def some_method
     end
 


### PR DESCRIPTION
In #272 @josephjaber noted the consistent class structure lacks specification where the `initialize` definition should be placed. @nilbus found that it is commonly the first instance method definition.

This change addends the consistent class structure so `initialize` is defined before other instance method definitions.