### PR TITLE
Add class/module naming example with a word after an acronym

### DIFF
--- a/README.md
+++ b/README.md
@@ -1913,12 +1913,20 @@ no parameters.
     ...
   end
 
+  class XmlSomething
+    ...
+  end
+
   # good
   class SomeClass
     ...
   end
 
   class SomeXML
+    ...
+  end
+  
+  class XMLSomething
     ...
   end
   ```


### PR DESCRIPTION
Adding an example of a more difficult  case (one with some readability downsides). In my opinion providing examples for the difficult / not ideal cases is more beneficial than giving only trivial / obvious / no downside examples.
Here is an example of a [popular ruby library](https://github.com/rest-client/rest-client) that chose the acronym to be not upper-cased, so that is an example how putting this in the guidelines could be beneficial to avoid such naming.