### PR TITLE
Disable find_by message

### DIFF
--- a/README.md
+++ b/README.md
@@ -3061,12 +3061,11 @@ resource cleanup when possible.
   ```
 
 * <a name="pad-string-interpolation"></a>
-  Consider padding string interpolation code with space. It more clearly sets
-  the code apart from the string.
+  Don't pad string interpolation code with space.
 <sup>[[link](#pad-string-interpolation)]</sup>
 
   ```Ruby
-  "#{ user.last_name }, #{ user.first_name }"
+  "#{user.last_name}, #{user.first_name}"
   ```
 
 * <a name="consistent-string-literals"></a>
@@ -3086,19 +3085,6 @@ resource cleanup when possible.
     # good
     name = 'Bozhidar'
     ```
-
-  * **(Option B)** Prefer double-quotes unless your string literal
-    contains `"` or escape characters you want to suppress.
-
-    ```Ruby
-    # bad
-    name = 'Bozhidar'
-
-    # good
-    name = "Bozhidar"
-    ```
-
-  The string literals in this guide are aligned with the first style.
 
 * <a name="no-character-literals"></a>
   Don't use the character literal syntax `?x`. Since Ruby 1.9 it's basically

--- a/README.md
+++ b/README.md
@@ -3,25 +3,6 @@
 > Role models are important. <br>
 > -- Officer Alex J. Murphy / RoboCop
 
-One thing has always bothered me as a Ruby developer - Python developers have a
-great programming style reference
-([PEP-8][]) and we never got an official
-guide, documenting Ruby coding style and best practices. And I do believe that
-style matters. I also believe that a great hacker community, such as Ruby has,
-should be quite capable of producing this coveted document.
-
-This guide started its life as our internal company Ruby coding guidelines
-(written by yours truly). At some point I decided that the work I was doing
-might be interesting to members of the Ruby community in general and that the
-world had little need for another internal company guideline. But the world
-could certainly benefit from a community-driven and community-sanctioned set of
-practices, idioms and style prescriptions for Ruby programming.
-
-Since the inception of the guide I've received a lot of feedback from members of
-the exceptional Ruby community around the world. Thanks for all the suggestions
-and the support! Together we can make a resource beneficial to each and every
-Ruby developer out there.
-
 By the way, if you're into Rails you might want to check out the complementary
 [Ruby on Rails Style Guide][rails-style-guide].
 
@@ -44,38 +25,11 @@ various highly regarded Ruby programming resources, such as
 ["Programming Ruby 1.9"][pickaxe] and
 ["The Ruby Programming Language"][trpl].
 
-There are some areas in which there is no clear consensus in the Ruby community
-regarding a particular style (like string literal quoting, spacing inside hash
-literals, dot position in multi-line method chaining, etc.). In such scenarios
-all popular styles are acknowledged and it's up to you to pick one and apply it
-consistently.
-
-This style guide evolves over time as additional conventions are
-identified and past conventions are rendered obsolete by changes in
-Ruby itself.
-
-Many projects have their own coding style guidelines (often derived
-from this guide). In the event of any conflicts, such
-project-specific guides take precedence for that project.
-
 You can generate a PDF or an HTML copy of this guide using
 [Transmuter][].
 
 [RuboCop][] is a code analyzer, based on this
 style guide.
-
-Translations of the guide are available in the following languages:
-
-* [Chinese Simplified](https://github.com/JuanitoFatas/ruby-style-guide/blob/master/README-zhCN.md)
-* [Chinese Traditional](https://github.com/JuanitoFatas/ruby-style-guide/blob/master/README-zhTW.md)
-* [French](https://github.com/porecreat/ruby-style-guide/blob/master/README-frFR.md)
-* [German](https://github.com/arbox/ruby-style-guide/blob/master/README-deDE.md)
-* [Japanese](https://github.com/fortissimo1997/ruby-style-guide/blob/japanese/README.ja.md)
-* [Korean](https://github.com/dalzony/ruby-style-guide/blob/master/README-koKR.md)
-* [Portuguese](https://github.com/rubensmabueno/ruby-style-guide/blob/master/README-PT-BR.md)
-* [Russian](https://github.com/arbox/ruby-style-guide/blob/master/README-ruRU.md)
-* [Spanish](https://github.com/alemohamad/ruby-style-guide/blob/master/README-esLA.md)
-* [Vietnamese](https://github.com/scrum2b/ruby-style-guide/blob/master/README-viVN.md)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > -- Officer Alex J. Murphy / RoboCop
 
 See also:
-[VHL Rails Style Guide][https://github.com/vhl/rails-style-guide].
+[VHL Rails Style Guide](https://github.com/vhl/rails-style-guide).
 
 # The Ruby Style Guide
 

--- a/README.md
+++ b/README.md
@@ -2086,16 +2086,14 @@ condition](#safe-assignment-in-condition).
     def some_method
     end
 
-    # protected and private methods are grouped near the end
-    protected
 
     def some_protected_method
     end
-
-    private
+    protected :some_protected_method
 
     def some_private_method
     end
+    private :some_private_method
   end
   ```
 
@@ -2404,13 +2402,11 @@ condition](#safe-assignment-in-condition).
 <sup>[[link](#visibility)]</sup>
 
 * <a name="indent-public-private-protected"></a>
-  Indent the `public`, `protected`, and `private` methods as much as the method
-  definitions they apply to. Leave one blank line above the visibility modifier
-  and one blank line below in order to emphasize that it applies to all methods
-  below it.
+ Use the 'protected' and 'private' methods to explicitly declare a method as protected/private.
 <sup>[[link](#indent-public-private-protected)]</sup>
 
   ```Ruby
+  # bad
   class SomeClass
     def public_method
       # ...
@@ -2425,6 +2421,22 @@ condition](#safe-assignment-in-condition).
     def another_private_method
       # ...
     end
+  end
+  
+  class SomeClass
+    def public_method
+      # ...
+    end
+
+    def private_method
+      # ...
+    end
+    private :private_method
+  
+    def another_private_method
+      # ...
+    end
+    private :another_private_method
   end
   ```
 

--- a/README.md
+++ b/README.md
@@ -405,13 +405,9 @@ style guide.
   ```
 
 * <a name="consistent-multi-line-chains"></a>
-    Adopt a consistent multi-line method chaining style. There are two
-    popular styles in the Ruby community, both of which are considered
-    good - leading `.` (Option A) and trailing `.` (Option B).
-<sup>[[link](#consistent-multi-line-chains)]</sup>
-
-  * **(Option A)** When continuing a chained method invocation on
+  When continuing a chained method invocation on
     another line keep the `.` on the second line.
+<sup>[[link](#consistent-multi-line-chains)]</sup>
 
     ```Ruby
     # bad - need to consult first line to understand second line
@@ -422,23 +418,6 @@ style guide.
     one.two.three
       .four
     ```
-
-  * **(Option B)** When continuing a chained method invocation on another line,
-    include the `.` on the first line to indicate that the
-    expression continues.
-
-    ```Ruby
-    # bad - need to read ahead to the second line to know that the chain continues
-    one.two.three
-      .four
-
-    # good - it's immediately clear that the expression continues beyond the first line
-    one.two.three.
-      four
-    ```
-
-  A discussion on the merits of both alternative styles can be found
-  [here](https://github.com/bbatsov/ruby-style-guide/pull/176).
 
 * <a name="no-double-indent"></a>
     Align the parameters of a method call if they span more than one

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > Role models are important. <br>
 > -- Officer Alex J. Murphy / RoboCop
 
-By the way, if you're into Rails you might want to check out the complementary
-[Ruby on Rails Style Guide][rails-style-guide].
+See also:
+[VHL Rails Style Guide][https://github.com/vhl/rails-style-guide].
 
 # The Ruby Style Guide
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 See also:
 [VHL Rails Style Guide](https://github.com/vhl/rails-style-guide).
 
+Here's how our styles are different from the community style guide this is based on:
+https://github.com/bbatsov/ruby-style-guide/compare/master...vhl:master
+
 # The Ruby Style Guide
 
 This Ruby style guide recommends best practices so that real-world Ruby

--- a/README.md
+++ b/README.md
@@ -193,13 +193,7 @@ style guide.
 
   ```
 
-  The first variant is slightly more readable (and arguably more
-  popular in the Ruby community in general). The second variant has
-  the advantage of adding visual difference between block and hash
-  literals. Whichever one you pick - apply it consistently.
-
-  As far as embedded expressions go, there are also two acceptable
-  options:
+  For embedded expressions don't add spaces around the variable inside the curly braces:
 
   ```Ruby
   # bad
@@ -207,13 +201,7 @@ style guide.
   
   # good - no spaces
   "string#{expr}"
-
   ```
-
-  The first style is extremely more popular and you're generally
-  advised to stick with it. The second, on the other hand, is
-  (arguably) a bit more readable. As with hashes - pick one style
-  and apply it consistently.
 
 * <a name="no-spaces-braces"></a>
   No spaces after `(`, `[` or before `]`, `)`.

--- a/README.md
+++ b/README.md
@@ -231,11 +231,12 @@ Translations of the guide are available in the following languages:
   strings. For hash literals two styles are considered acceptable.
 
   ```Ruby
+  # bad - no space after { and before }
+  {one: 1, two: 2}
+  
   # good - space after { and before }
   { one: 1, two: 2 }
 
-  # good - no space after { and before }
-  {one: 1, two: 2}
   ```
 
   The first variant is slightly more readable (and arguably more
@@ -247,11 +248,12 @@ Translations of the guide are available in the following languages:
   options:
 
   ```Ruby
+  # bad
+  "string#{ expr }"
+  
   # good - no spaces
   "string#{expr}"
 
-  # ok - arguably more readable
-  "string#{ expr }"
   ```
 
   The first style is extremely more popular and you're generally

--- a/vhl-rubocop.yml
+++ b/vhl-rubocop.yml
@@ -17,3 +17,6 @@ Metrics/LineLength:
 
 ActionFilter:
   Enabled: false
+
+FindBy:
+  Enabled: false

--- a/vhl-rubocop.yml
+++ b/vhl-rubocop.yml
@@ -14,3 +14,6 @@ Style/Documentation:
 
 Metrics/LineLength:
   Max: 80
+
+ActionFilter:
+  Enabled: false

--- a/vhl-rubocop.yml
+++ b/vhl-rubocop.yml
@@ -1,0 +1,16 @@
+AllCops:
+  RunRailsCops: true
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+    - 'vendor/**/*'
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 120


### PR DESCRIPTION
Rubocop shows a `use find_by instead of where.first`, but this method belongs to rails >= 4.0.2.