### PR TITLE
 fix(typo): Fix typo in tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3691,7 +3691,7 @@ resource cleanup when possible.
 
 ## Tools
 
-Here's some tools to help you automatically check Ruby code against
+Here are some tools to help you automatically check Ruby code against
 this guide.
 
 ### RuboCop


### PR DESCRIPTION
Fix subject-noun agreement in the tools section.

"Here's some tools..." was corrected to "Here are some tools..."