### PR TITLE
Add negative example for spaces around parens/brackets rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ Translations of the guide are available in the following languages:
 <sup>[[link](#no-spaces-braces)]</sup>
 
   ```Ruby
+  # bad
+  some( arg ).other
+  [ 1, 2, 3 ].size
+
+  # good
   some(arg).other
   [1, 2, 3].size
   ```


### PR DESCRIPTION
I noticed there was no ``#bad`` example for the [no-spaces-braces](https://github.com/etdev/ruby_notes/blob/master/ruby_sg/ruby_styleguide_etdev.md#no-spaces-braces) rule, which could make it unclear what's meant by "No spaces after ``(``, ``[`` or before ``]``, ``)``".  Most similar rules have both ``#bad`` and ``#good`` examples.

So I've added a ``#bad`` example for this rule:

  ```Ruby
  # bad
  some( arg ).other
  [ 1, 2, 3 ].size

  # good
  some(arg).other
  [1, 2, 3].size
  ```

Let me know what you think.