### PR TITLE
Don't rescue Exception in exception-ordering rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2857,7 +2857,6 @@ no parameters.
   # also good
   begin
     # an exception occurs here
-
   rescue StandardError => e
     # exception handling
   end
@@ -2872,18 +2871,18 @@ no parameters.
   # bad
   begin
     # some code
-  rescue Exception => e
-    # some handling
   rescue StandardError => e
+    # some handling
+  rescue IOError => e
     # some handling that will never be executed
   end
 
   # good
   begin
     # some code
-  rescue StandardError => e
+  rescue IOError => e
     # some handling
-  rescue Exception => e
+  rescue StandardError => e
     # some handling
   end
   ```


### PR DESCRIPTION
The ``#good`` code example for the [exception-ordering](https://github.com/bbatsov/ruby-style-guide#exception-ordering) rule rescues from ``Exception``, which we're specifically told to avoid in the previous rule, [no-blind-rescues](https://github.com/bbatsov/ruby-style-guide#no-blind-rescues).  

I propose switching to ``IOError`` and ``StandardError`` in the [exception-ordering](https://github.com/bbatsov/ruby-style-guide#exception-ordering) rule.

Also removes unnecessary newline from [no-blind-rescues](https://github.com/bbatsov/ruby-style-guide#no-blind-rescues).