### PR TITLE
Add example code for gsub-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3439,8 +3439,14 @@ resource cleanup when possible.
   ```
 
 * <a name="gsub-blocks"></a>
-  For complex replacements `sub`/`gsub` can be used with block or hash.
+  For complex replacements `sub`/`gsub` can be used with a block or a hash.
 <sup>[[link](#gsub-blocks)]</sup>
+
+  ```Ruby
+  words = 'foo bar'
+  words.sub(/f/, 'f' => 'F') # => 'Foo bar'
+  words.gsub(/\w+/) { |word| word.capitalize } # => 'Foo Bar'
+  ```
 
 ## Percent Literals
 


### PR DESCRIPTION
Adds example usages of `sub`/`gsub` with block and hash arguments to the [gsub-blocks](https://github.com/bbatsov/ruby-style-guide/blob/master/README.md#gsub-blocks) rule

Also fixes grammar slightly.