### PR TITLE
Re-word non-capturing-regexp rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -3365,12 +3365,15 @@ resource cleanup when possible.
   ```
 
 * <a name="non-capturing-regexp"></a>
-  Use non-capturing groups when you don't use captured result of parentheses.
+  Use non-capturing groups when you don't use the captured result.
 <sup>[[link](#non-capturing-regexp)]</sup>
 
   ```Ruby
-  /(first|second)/   # bad
-  /(?:first|second)/ # good
+  # bad
+  /(first|second)/
+
+  # good
+  /(?:first|second)/
   ```
 
 * <a name="no-perl-regexp-last-matchers"></a>


### PR DESCRIPTION
Fixes slightly awkward wording for [non-capturing-regexp](https://github.com/bbatsov/ruby-style-guide/blob/master/README.md#non-capturing-regexp) rule

Also moves ``# bad`` and ``# good` comments to the line above their corresponding code examples, in line with the other code examples.