### PR TITLE
Add #bad example for string-concat

### DIFF
--- a/README.md
+++ b/README.md
@@ -3301,6 +3301,14 @@ resource cleanup when possible.
 <sup>[[link](#concat-strings)]</sup>
 
   ```Ruby
+  # bad
+  html = ''
+  html += '<h1>Page title</h1>'
+
+  paragraphs.each do |paragraph|
+    html += "<p>#{paragraph}</p>"
+  end
+
   # good and also fast
   html = ''
   html << '<h1>Page title</h1>'


### PR DESCRIPTION
Adds `#bad` example for [concat-strings](https://github.com/bbatsov/ruby-style-guide/blob/master/README.md#concat-strings) rule.