### PR TITLE
No unnecessary non-nil checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,7 +875,7 @@ Translations of the guide are available in the following languages:
 
   # good
   x = 'test'
-  unless x.nil?
+  if x
     # body omitted
   end
   ```


### PR DESCRIPTION
They are discouraged in another part of the style guide [1].

[1] https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks
