### PR TITLE
Private and Protected methods should have extra level of indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2262,16 +2262,14 @@ no parameters.
     def some_method
     end
 
-    # protected and private methods are grouped near the end
+    # protected and private methods are grouped near the end indented with extra level
     protected
-
-    def some_protected_method
-    end
+      def some_protected_method
+      end
 
     private
-
-    def some_private_method
-    end
+      def some_private_method
+      end
   end
   ```
 
@@ -2593,14 +2591,13 @@ no parameters.
     end
 
     private
+      def private_method
+        # ...
+      end
 
-    def private_method
-      # ...
-    end
-
-    def another_private_method
-      # ...
-    end
+      def another_private_method
+        # ...
+      end
   end
   ```
 


### PR DESCRIPTION
This will solve the issue of having too many private methods and loosing
visual track of which methods are public and which private, therefore
doing inline `private` 
- https://github.com/bbatsov/ruby-style-guide/issues/449
- https://github.com/bbatsov/ruby-style-guide/issues/487

This also comply to scissors rule http://www.eq8.eu/blogs/16-scissors-rule-in-coding
