### PR TITLE
clarify why 'and' and 'or' are evil

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,12 +914,6 @@ Translations of the guide are available in the following languages:
   # boolean expression
   ok = got_needed_arguments and arguments_are_valid
 
-  # boolean expression
-  error = lack_needed_arguments or arguments_are_invalid
-
-  # control flow
-  document.validate and document.save
-
   # control flow
   document.save or fail(RuntimError, "Failed to save document!")
 
@@ -927,21 +921,12 @@ Translations of the guide are available in the following languages:
   # boolean expression
   ok = got_needed_arguments && arguments_are_valid
 
-  # boolean expression
-  error = lack_needed_arguments || arguments_are_invalid
-
-  # control flow
-  document.save if document.valid?  # note also more idiomatic name
-
   # control flow
   fail(RuntimeError, "Failed to save document!") unless document.save
 
   # ok
   # control flow
-  document.validate && document.save
-
-  # control flow
-  document.save || die("Failed to save document!")
+  document.save || fail(RuntimeError, "Failed to save document!")
   ```
 
 * <a name="no-multiline-ternary"></a>

--- a/README.md
+++ b/README.md
@@ -903,29 +903,56 @@ Translations of the guide are available in the following languages:
   ```
 
 * <a name="no-and-or-or"></a>
-  The `and` and `or` keywords are banned. It's just not worth it. Always use
-  `&&` and `||` instead.
+  The `and` and `or` keywords are banned. The minimal added readability is just
+  not worth the high probability of introducing subtle bugs. For boolean
+  expressions, always use `&&` and `||` instead. When doing flow control, use
+  `if` and `unless`; `&&` and `||` are also acceptable but less clear.
 <sup>[[link](#no-and-or-or)]</sup>
 
   ```Ruby
-  # bad
-  # boolean expression
-  if some_condition and some_other_condition
-    do_something
-  end
+  # BAD:
 
-  # control flow
-  document.saved? or document.save!
+  # boolean and-expression
+  ok = got_needed_arguments and arguments_are_valid
+  # if got_needed_arguments is true but arguments_are_valid is false,
+  # you might expect ok to be false, but it will be true!
 
-  # good
-  # boolean expression
-  if some_condition && some_other_condition
-    do_something
-  end
+  # boolean or-expression
+  error = lack_needed_arguments or arguments_are_invalid
+  # if lack_needed_arguments is false but arguments_are_invalid is true,
+  # you might expect error to be true, but it will be false!
 
-  # control flow
-  document.saved? || document.save!
+  # control flow checking for success
+  document.validate and document.save
+
+  # control flow checking for failure
+  document.save or die "Failed to save document!"
+
+  # GOOD:
+
+  # boolean and-expression
+  ok = got_needed_arguments && arguments_are_valid
+
+  # boolean or-expression
+  error = lack_needed_arguments || arguments_are_invalid
+
+  # control flow checking for success
+  document.save if document.valid?  # note also more idiomatic name
+
+  # control flow checking for failure
+  die("Failed to save document!") unless document.save
+
+  # ALSO OK:
+
+  # control flow checking for success
+  document.validate && document.save
+
+  # control flow checking for failure
+  document.save || die("Failed to save document!")
   ```
+
+  See the `and != &&` and `or != ||` [slides from Dave Aronson's Ruby Gotchas
+  presentation](http://bit.ly/RubyGotchas) for further explanation.
 
 * <a name="no-multiline-ternary"></a>
   Avoid multi-line `?:` (the ternary operator); use `if/unless` instead.

--- a/README.md
+++ b/README.md
@@ -905,54 +905,44 @@ Translations of the guide are available in the following languages:
 * <a name="no-and-or-or"></a>
   The `and` and `or` keywords are banned. The minimal added readability is just
   not worth the high probability of introducing subtle bugs. For boolean
-  expressions, always use `&&` and `||` instead. When doing flow control, use
+  expressions, always use `&&` and `||` instead. For flow control, use
   `if` and `unless`; `&&` and `||` are also acceptable but less clear.
 <sup>[[link](#no-and-or-or)]</sup>
 
   ```Ruby
-  # BAD:
-
-  # boolean and-expression
+  # bad
+  # boolean expression
   ok = got_needed_arguments and arguments_are_valid
-  # if got_needed_arguments is true but arguments_are_valid is false,
-  # you might expect ok to be false, but it will be true!
 
-  # boolean or-expression
+  # boolean expression
   error = lack_needed_arguments or arguments_are_invalid
-  # if lack_needed_arguments is false but arguments_are_invalid is true,
-  # you might expect error to be true, but it will be false!
 
-  # control flow checking for success
+  # control flow
   document.validate and document.save
 
-  # control flow checking for failure
-  document.save or die "Failed to save document!"
+  # control flow
+  document.save or fail(RuntimError, "Failed to save document!")
 
-  # GOOD:
-
-  # boolean and-expression
+  # good
+  # boolean expression
   ok = got_needed_arguments && arguments_are_valid
 
-  # boolean or-expression
+  # boolean expression
   error = lack_needed_arguments || arguments_are_invalid
 
-  # control flow checking for success
+  # control flow
   document.save if document.valid?  # note also more idiomatic name
 
-  # control flow checking for failure
-  die("Failed to save document!") unless document.save
+  # control flow
+  fail(RuntimeError, "Failed to save document!") unless document.save
 
-  # ALSO OK:
-
-  # control flow checking for success
+  # ok
+  # control flow
   document.validate && document.save
 
-  # control flow checking for failure
+  # control flow
   document.save || die("Failed to save document!")
   ```
-
-  See the `and != &&` and `or != ||` [slides from Dave Aronson's Ruby Gotchas
-  presentation](http://bit.ly/RubyGotchas) for further explanation.
 
 * <a name="no-multiline-ternary"></a>
   Avoid multi-line `?:` (the ternary operator); use `if/unless` instead.


### PR DESCRIPTION
This PR adds the rationale for the rule that `and` and `or` are banned.  (You may have thought it obvious, but I've seen enough people wondering, that I don't think it's as obvious as it need to be!)
