### PR TITLE
Fix link to Wikipedia article on SOLID

### DIFF
--- a/README.md
+++ b/README.md
@@ -2387,7 +2387,7 @@ no parameters.
 
 * <a name="solid-design"></a>
   Try to make your classes as
-  [SOLID](https://en.wikipedia.org/wiki/SOLID\(object-oriented_design\)) as
+  [SOLID](https://en.wikipedia.org/wiki/SOLID_\(object-oriented_design\)) as
   possible.
 <sup>[[link](#solid-design)]</sup>
 


### PR DESCRIPTION
I'm sure that's because everyone knows what SOLID is and, thus, never clicked the link, but we still need to keep links correct, don't we? =)