### PR TITLE
Keep consistency on the Classes & Modules link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Translations of the guide are available in the following languages:
 * [Naming](#naming)
 * [Comments](#comments)
   * [Comment Annotations](#comment-annotations)
-* [Classes](#classes--modules)
+* [Classes & Modules](#classes--modules)
 * [Exceptions](#exceptions)
 * [Collections](#collections)
 * [Strings](#strings)


### PR DESCRIPTION
Hi guys,

The section name is "Classes & Modules" but the link is "Classes".

This fixes the link to follow the same name of the section.

Thanks