### PR TITLE
Fix parameter names in good example for optional args

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ Translations of the guide are available in the following languages:
   some_method('w', 'x', 'y', 'z') # => 'w, x, y, z'
 
   # good
-  def some_method(c, d, a = 1, b = 2)
+  def some_method(a, b, c = 1, d = 2)
     puts "#{a}, #{b}, #{c}, #{d}"
   end
 


### PR DESCRIPTION
Method body assumes parameters are ordered a, b, c, d, not c, d, a, b.