### PR TITLE
Enhances array literals with meaningful brackets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3113,7 +3113,7 @@ resource cleanup when possible.
   ```
 
 * <a name="hash-each"></a>
-  Use `Hash#each_key` instead of `Hash#key.each` and `Hash#each_value`
+  Use `Hash#each_key` instead of `Hash#keys.each` and `Hash#each_value`
   instead of `Hash#values.each`.
 <sup>[[link](#hash-each)]</sup>
 

--- a/README.md
+++ b/README.md
@@ -2287,7 +2287,7 @@ no parameters.
   ```
 
 * <a name="file-classes"></a>
-  Don't nest multi line classes within classes. Try to have such nested
+  Don't nest multi-line classes within classes. Try to have such nested
   classes each in their own file in a folder named like the containing class.
 <sup>[[link](#file-classes)]</sup>
 

--- a/README.md
+++ b/README.md
@@ -2714,7 +2714,7 @@ no parameters.
 
 ## Exceptions
 
-* <a name="prefer-raise"></a>
+* <a name="prefer-raise-over-fail"></a>
   Prefer `raise` over `fail` for exceptions.
   <sup>[[link](#prefer-raise-over-fail)]</sup>
 

--- a/README.md
+++ b/README.md
@@ -3627,19 +3627,20 @@ resource cleanup when possible.
 <sup>[[link](#percent-s)]</sup>
 
 * <a name="percent-literal-braces"></a>
-  Prefer `()` as delimiters for all `%` literals, except `%r`. Since parentheses
-  often appear inside regular expressions in many scenarios a less common
-  character like `{` might be a better choice for a delimiter, depending on the
-  regexp's content.
+  Prefer `()` as delimiters for all `%` literals, except `%r` and array 
+  literals. Since parentheses often appear inside regular expressions in many 
+  scenarios a less common character like `{` might be a better choice for a 
+  delimiter, depending on the regexp's content. When creating array literals it
+  is more expressive to use `[]`.
 <sup>[[link](#percent-literal-braces)]</sup>
 
   ```Ruby
   # bad
-  %w[one two three]
+  %w<one two three>
   %q{"Test's king!", John said.}
 
   # good
-  %w(one two three)
+  %w[one two three]
   %q("Test's king!", John said.)
   ```
 


### PR DESCRIPTION
Change the style guide in terms of using square brackets for Array literals instead of parentheses for expressiveness reasons (I think percent literal delimiters should be meaningful). Square brackets reveal the intention, that the literal creates an Array, like:

~~~ruby
# good
%w[one two three]
%i[one two three]
~~~