### PR TITLE
Warn about scope in loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1119,6 +1119,10 @@ condition](#safe-assignment-in-condition).
     end
     ```
 
+  :warning: Switching from e.g. `while` to `loop` changes the
+  scope of local variables. Variables defined in a `loop` go
+  out of scope after each iteration.
+
 * <a name="loop-with-break"></a>
   Use `Kernel#loop` with `break` rather than `begin/end/until` or
   `begin/end/while` for post-loop tests.


### PR DESCRIPTION
If people blindly switch from `while` to `loop`, they may get stung by this subtle change in scope. Let's warn them.

```
while true do # exits on second iter.
  done ||= false
  break if done
  done = true
end

loop do # never exits
  done ||= false
  break if done
  done = true
end
```
