### PR TITLE
Change Array check splat(*) example from "good" to "bad":

### DIFF
--- a/README.md
+++ b/README.md
@@ -1726,18 +1726,18 @@ no parameters.
   # => 'one, two, three'
   ```
 
-* <a name="splat-arrays"></a>
-  Use `[*var]` or `Array()` instead of explicit `Array` check, when dealing
+* <a name="array-coercion"></a>
+  Use `Array()` instead of explicit `Array` check or `[*var]`, when dealing
   with a variable you want to treat as an Array, but you're not certain it's an
   array.
-<sup>[[link](#splat-arrays)]</sup>
+<sup>[[link](#array-coercion)]</sup>
 
   ```Ruby
   # bad
   paths = [paths] unless paths.is_a? Array
   paths.each { |path| do_something(path) }
 
-  # good
+  # bad (always creates a new Array instance)
   [*paths].each { |path| do_something(path) }
 
   # good (and a bit more readable)


### PR DESCRIPTION
Using the splat technique `[*object]` will _always_ instantiate a new Array object, whereas
`Array(object)` will return the same object it is given as an argument if that argument is already an Array.

```ruby
> my_array = [1, 2, 3]
 => [1, 2, 3]

> my_array.object_id
 => 70240742761080

# This example is bad because it creates a new Array instance
# as demonstrated by showing that it has a different object_id.
>   [*my_array].object_id
 => 70240734757900

# This returns the same Array instance.
>   Array(my_array).object_id
 => 70240742761080
```