### PR TITLE
Fix indentation in naming section and typo in error subclass section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1990,7 +1990,7 @@ no parameters.
   end
 
   def SomeMethod
-   # some code
+    # some code
   end
 
   # good
@@ -2984,7 +2984,7 @@ resource cleanup when possible.
   ```
 
 * <a name="standard-exceptions"></a>
-  Favor the use of exceptions for the standard library over introducing new
+  Favor the use of exceptions from the standard library over introducing new
   exception classes.
 <sup>[[link](#standard-exceptions)]</sup>
 


### PR DESCRIPTION
Indentation was slightly off in naming section: 
https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars

And there was a typo in the section about error subclasses:
https://github.com/bbatsov/ruby-style-guide#standard-exceptions
> Favor the use of exceptions ~~for~~ from the standard library over introducing new exception classes.