### PR TITLE
Gather rules about spaces around braces in one place

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ Translations of the guide are available in the following languages:
   ```Ruby
   sum = 1 + 2
   a, b = 1, 2
-  [1, 2, 3].each { |e| puts e }
   class FooError < StandardError; end
   ```
 
@@ -228,16 +227,17 @@ Translations of the guide are available in the following languages:
 
 * <a name="spaces-braces"></a>
   No spaces after `(`, `[` or before `]`, `)`.
+  Use spaces around `{` and before `}`.
 <sup>[[link](#spaces-braces)]</sup>
 
   ```Ruby
   # bad
   some( arg ).other
-  [ 1, 2, 3 ].size
+  [ 1, 2, 3 ].each{|e| puts e}
 
   # good
   some(arg).other
-  [1, 2, 3].size
+  [1, 2, 3].each { |e| puts e }
   ```
 
   `{` and `}` deserve a bit of clarification, since they are used

--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ Translations of the guide are available in the following languages:
   ```
 
 * <a name="spaces-operators"></a>
-  Use spaces around operators, after commas, colons and semicolons, around `{`
-  and before `}`. Whitespace might be (mostly) irrelevant to the Ruby
-  interpreter, but its proper use is the key to writing easily readable code.
+  Use spaces around operators, after commas, colons and semicolons.
+  Whitespace might be (mostly) irrelevant to the Ruby interpreter,
+  but its proper use is the key to writing easily readable code.
 <sup>[[link](#spaces-operators)]</sup>
 
   ```Ruby
@@ -226,26 +226,9 @@ Translations of the guide are available in the following languages:
   e = M * c**2
   ```
 
-  `{` and `}` deserve a bit of clarification, since they are used
-  for block and hash literals, as well as string interpolation.
-  For hash literals two styles are considered acceptable.
-
-  ```Ruby
-  # good - space after { and before }
-  { one: 1, two: 2 }
-
-  # good - no space after { and before }
-  {one: 1, two: 2}
-  ```
-
-  The first variant is slightly more readable (and arguably more
-  popular in the Ruby community in general). The second variant has
-  the advantage of adding visual difference between block and hash
-  literals. Whichever one you pick - apply it consistently.
-
-* <a name="no-spaces-braces"></a>
+* <a name="spaces-braces"></a>
   No spaces after `(`, `[` or before `]`, `)`.
-<sup>[[link](#no-spaces-braces)]</sup>
+<sup>[[link](#spaces-braces)]</sup>
 
   ```Ruby
   # bad
@@ -255,6 +238,33 @@ Translations of the guide are available in the following languages:
   # good
   some(arg).other
   [1, 2, 3].size
+  ```
+
+  `{` and `}` deserve a bit of clarification, since they are used
+  for block and hash literals, as well as string interpolation.
+
+  For hash literals two styles are considered acceptable.
+  The first variant is slightly more readable (and arguably more
+  popular in the Ruby community in general). The second variant has
+  the advantage of adding visual difference between block and hash
+  literals. Whichever one you pick - apply it consistently.
+
+  ```Ruby
+  # good - space after { and before }
+  { one: 1, two: 2 }
+
+  # good - no space after { and before }
+  {one: 1, two: 2}
+  ```
+
+  With interpolated expressions, there should be no padded-spacing inside the braces.
+
+  ```Ruby
+  # bad
+  "From: #{ user.first_name }, #{ user.last_name }"
+
+  # good
+  "From: #{user.first_name}, #{user.last_name}"
   ```
 
 * <a name="no-space-bang"></a>


### PR DESCRIPTION
* https://github.com/bbatsov/ruby-style-guide#pad-string-interpolation

  This rule is really about code layout instead of strings. Makes more sense to put it in the "Source Code Layout" section.

* https://github.com/bbatsov/ruby-style-guide#spaces-operators

  By splitting out the `{ }` part and putting it together with `( )` and `[ ]`, it would make the rules in question easier to follow, compare and locate.