### PR TITLE
Rectify no-parens-if

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,7 +995,7 @@ Translations of the guide are available in the following languages:
   Avoid the use of `!!`.
 <sup>[[link](#no-bang-bang)]</sup>
 
-  `!!` converts a value to boolean, but you don't need this explicit 
+  `!!` converts a value to boolean, but you don't need this explicit
   conversion in the condition of a control expression; using it only
   obscures your intention. If you want to do a `nil` check, use `nil?`
   instead.
@@ -1132,10 +1132,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* <a name="no-parens-if"></a>
+* <a name="no-parens-around-condition"></a>
   Don't use parentheses around the condition of an
   `if`/`unless`/`while`/`until`.
-<sup>[[link](#no-parens-if)]</sup>
+<sup>[[link](#no-parens-around-condition)]</sup>
 
   ```Ruby
   # bad
@@ -3589,16 +3589,16 @@ resource cleanup when possible.
   ```Ruby
   # bad - uses DateTime for current time
   DateTime.now
-  
+
   # good - uses Time for current time
   Time.now
-  
+
   # bad - uses DateTime for modern date
   DateTime.iso8601('2016-06-29')
-  
+
   # good - uses Date for modern date
   Date.iso8601('2016-06-29')
-  
+
   # good - uses DateTime with start argument for historical date
   DateTime.iso8601('1751-04-23', Date::ENGLAND)
   ```

--- a/README.md
+++ b/README.md
@@ -1133,8 +1133,7 @@ Translations of the guide are available in the following languages:
   ```
 
 * <a name="no-parens-around-condition"></a>
-  Don't use parentheses around the condition of an
-  `if`/`unless`/`while`/`until`.
+  Don't use parentheses around the condition of a control expression.
 <sup>[[link](#no-parens-around-condition)]</sup>
 
   ```Ruby


### PR DESCRIPTION
Missing `case` and `for`. More accurate this way.