### PR TITLE
Remove "no-semicolon-ifs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,19 +860,6 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* <a name="no-semicolon-ifs"></a>
-  Do not use `if x; ...`. Use the ternary
-  operator instead.
-<sup>[[link](#no-semicolon-ifs)]</sup>
-
-  ```Ruby
-  # bad
-  result = if some_condition; something else something_else end
-
-  # good
-  result = some_condition ? something : something_else
-  ```
-
 * <a name="use-if-case-returns"></a>
   Leverage the fact that `if` and `case` are expressions which return a
   result.


### PR DESCRIPTION
Redundant, already covered by [no-semicolon](https://github.com/bbatsov/ruby-style-guide#no-semicolon).