### PR TITLE
Fixed code example (no-nested-conditionals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1895,7 +1895,7 @@ no parameters.
   # bad
   def compute_thing(thing)
     if thing[:foo]
-      update_with_bar(thing)
+      update_with_bar(thing[:foo])
       if thing[:foo][:bar]
         partial_compute(thing)
       else


### PR DESCRIPTION
Fixed typo in code sample from [[no-nested-conditionals](https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals)]

Сode in the "good" and  "bad" examples doing different things.

`update_with_bar(thing)` in "bad" sample is been not equal to
`update_with_bar(thing[:foo])` from "good" sample.