### PR TITLE
add notion about default rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -4006,6 +4006,18 @@ resource cleanup when possible.
   Avoid more than three levels of block nesting.
 <sup>[[link](#three-is-the-number-thou-shalt-count)]</sup>
 
+* <a name="default-rake-task-for-tests-and-linters"></a>
+  Setup default `rake` task to run all tests and linters used in your project.
+<sup>[[link](#default-rake-task-for-tests-and-linters)]</sup>
+
+  ```Bash
+  # bad
+  rspec && cucumber && rubocop
+
+  # good
+  rake
+  ```
+
 * <a name="be-consistent"></a>
   Be consistent. In an ideal world, be consistent with these guidelines.
 <sup>[[link](#be-consistent)]</sup>


### PR DESCRIPTION
I've seen this as a rather widely used approach. For example, it's used for running tests in Rails (both [itself](https://github.com/rails/rails/blob/master/Rakefile#L17) and Rails apps), [Sinatra](https://github.com/sinatra/sinatra/blob/master/Rakefile#L6), [rubocop](https://github.com/bbatsov/rubocop/blob/master/Rakefile#L35), [thin](https://github.com/macournoyer/thin/blob/master/Rakefile#L8), [hanami](https://github.com/hanami/hanami/blob/master/Rakefile#L17), etc.
