### PR TITLE
Improve indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,10 +409,10 @@ Translations of the guide are available in the following languages:
   ```Ruby
   # bad - easier to move/add/remove parameters, but still not preferred
   some_method(
-               size,
-               count,
-               color,
-             )
+    size,
+    count,
+    color,
+  )
 
   # bad
   some_method(size, count, color, )


### PR DESCRIPTION
This particular code sample is not about indentation, but about the use of trailing commas in method arguments. So the standard indentation should be used, and it still conveys the same message without the added ugliness of the non-standard indentation previously used.