### PR TITLE
Fix misleading typo in the internal DSL parentheses omission rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,9 +717,9 @@ Translations of the guide are available in the following languages:
 
     ```Ruby
     # bad
-    expect(bowling.score).to eq 0
-    # good
     expect(bowling.score).to eq(0)
+    # good
+    expect(bowling.score).to eq 0
     ```
 
   * Methods that have "keyword" status in Ruby:


### PR DESCRIPTION
It's either that or the example should be moved out of the "Only omit parentheses for" section.