### PR TITLE
Add a section on mixin grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -2470,6 +2470,24 @@ no parameters.
   end
   ```
 
+* <a name="mixin-grouping"></a>
+  Split multiple mixins into separate statements.
+<sup>[[link](#mixin-grouping)]</sup>
+
+  ```Ruby
+  # bad
+  class Person
+    include Foo, Bar
+  end
+  
+  # good
+  class Person
+    # multiple mixins go in separate statements
+    include Foo
+    include Bar
+  end
+  ```
+
 * <a name="file-classes"></a>
   Don't nest multi-line classes within classes. Try to have such nested
   classes each in their own file in a folder named like the containing class.


### PR DESCRIPTION
This change adds a suggested rule on mixin grouping. Some rationales for this could be:

 - Easier to see the number of dependencies for a `class` or `module`.
 - Easier and less error prone to change or remove a mixin.

Mostly, however, it is for consistency.