### PR TITLE
Add magic comments section into TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Translations of the guide are available in the following languages:
 * [Naming](#naming)
 * [Comments](#comments)
   * [Comment Annotations](#comment-annotations)
+  * [Magic Comments](#magic-comments)
 * [Classes & Modules](#classes--modules)
 * [Exceptions](#exceptions)
 * [Collections](#collections)


### PR DESCRIPTION
In #616 , guideline for magic comments is added. However, I can't find the section in the table of contents. 
This change adds the section into the table of content. 