### PR TITLE
Fix `method_missing` method definition example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4215,7 +4215,7 @@ resource cleanup when possible.
 
     ```ruby
     # bad
-    def method_missing?(meth, *params, &block)
+    def method_missing(meth, *params, &block)
       if /^find_by_(?<prop>.*)/ =~ meth
         # ... lots of code to do a find_by
       else
@@ -4224,7 +4224,7 @@ resource cleanup when possible.
     end
 
     # good
-    def method_missing?(meth, *params, &block)
+    def method_missing(meth, *params, &block)
       if /^find_by_(?<prop>.*)/ =~ meth
         find_by(prop, *params, &block)
       else


### PR DESCRIPTION
Hi, everyone!

Just fixing `method_missing` definition example - it should not have a trailing `?`.