### PR TITLE
Cleanup magic comments section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2469,32 +2469,39 @@ no parameters.
 ### Magic Comments
 
 * <a name="magic-comments-first"></a>
-  Place magic comments above all code and documentation. Magic comments should only go below shebangs if they are needed in your source file.
-<sup>[[link](#magic-comments-first)]</sup>
+  Place magic comments above all code and documentation in a file (except shebangs, which are discussed next).
 
   ```ruby
   # good
   # frozen_string_literal: true
+
   # Some documentation about Person
   class Person
   end
 
   # bad
   # Some documentation about Person
+
   # frozen_string_literal: true
   class Person
   end
   ```
 
+* <a name="below-shebang"></a>
+  Place magic comments below shebangs when they are present in a file.
+<sup>[[link](#below-shebang)]</sup>
+
   ```ruby
   # good
   #!/usr/bin/env ruby
   # frozen_string_literal: true
+
   App.parse(ARGV)
 
   # bad
   # frozen_string_literal: true
   #!/usr/bin/env ruby
+
   App.parse(ARGV)
   ```
 
@@ -3122,7 +3129,7 @@ no parameters.
     # ...other methods...
   end
   ```
-  
+
 ## Exceptions
 
 * <a name="prefer-raise-over-fail"></a>


### PR DESCRIPTION
The existing section is a little confusing so I attempted to clean it up.  The first rule talks about adding magic comments above all other code, but it also talks about putting them below shebangs.  My brain glossed over 

> Place magic comments above all code and documentation.

and went right to

> Magic comments should only go below shebangs if they are needed in your source file.

The very first code example, doesn't have anything to do with shebangs so I wasn't quite sure what I was looking at.  After a minute or two, I finally realized that the first example covers putting magic comments above everything else, and the second code example covered shebangs.

To make this a little more clear, I split the two thoughts into separate rules.