### PR TITLE
Update string literals quoting style with more descriptive examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3122,7 +3122,7 @@ no parameters.
     # ...other methods...
   end
   ```
-  
+
 ## Exceptions
 
 * <a name="prefer-raise-over-fail"></a>
@@ -3716,10 +3716,10 @@ resource cleanup when possible.
 
     ```ruby
     # bad
-    name = 'Bozhidar'
+    name = 'De\'Andre'
 
     # good
-    name = "Bozhidar"
+    name = "De'Andre"
     ```
 
   The string literals in this guide are aligned with the first style.

--- a/README.md
+++ b/README.md
@@ -3707,8 +3707,12 @@ resource cleanup when possible.
     # bad
     name = "Bozhidar"
 
+    name = 'De\'Andre'
+
     # good
     name = 'Bozhidar'
+
+    name = "De'Andre"
     ```
 
   * **(Option B)** Prefer double-quotes unless your string literal
@@ -3716,10 +3720,14 @@ resource cleanup when possible.
 
     ```ruby
     # bad
-    name = 'De\'Andre'
+    name = 'Bozhidar'
+
+    sarcasm = "I \"like\" it."
 
     # good
-    name = "De'Andre"
+    name = "Bozhidar"
+
+    sarcasm = 'I "like" it.'
     ```
 
   The string literals in this guide are aligned with the first style.


### PR DESCRIPTION
This PR updating string literals quoting style examples, cause they are the same for single and double quoted cases, which I find confusing. 