### PR TITLE
Don't use &&=

### DIFF
--- a/README.md
+++ b/README.md
@@ -1570,7 +1570,7 @@ condition](#safe-assignment-in-condition).
   ```
 
 * <a name="self-assignment"></a>
-  Use shorthand self assignment operators whenever applicable.
+  Use shorthand self assignment operators whenever applicable, except `&&=`.
 <sup>[[link](#self-assignment)]</sup>
 
   ```ruby
@@ -1588,7 +1588,7 @@ condition](#safe-assignment-in-condition).
   x **= y
   x /= y
   x ||= y
-  x &&= y
+  x = x && y
   ```
 
 * <a name="double-pipe-for-uninit"></a>
@@ -1640,7 +1640,7 @@ condition](#safe-assignment-in-condition).
   # good
   something = something && something.downcase
 
-  # better
+  # but don't do this
   something &&= something.downcase
   ```
 


### PR DESCRIPTION
Because it causes confusions and unexpected behaviors (by most people's standard).

https://stackoverflow.com/questions/47803567/in-ruby-operator-is-flaky#47803809
https://stackoverflow.com/questions/2982947/ruby-edge-case
http://www.rubyinside.com/what-rubys-double-pipe-or-equals-really-does-5488.html