### PR TITLE
Use `raise` consistently with guide in no-and-or-or examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,18 +1156,18 @@ Translations of the guide are available in the following languages:
   ok = got_needed_arguments and arguments_are_valid
 
   # control flow
-  document.save or fail(RuntimeError, "Failed to save document!")
+  document.save or raise("Failed to save document!")
 
   # good
   # boolean expression
   ok = got_needed_arguments && arguments_are_valid
 
   # control flow
-  fail(RuntimeError, "Failed to save document!") unless document.save
+  raise("Failed to save document!") unless document.save
 
   # ok
   # control flow
-  document.save || fail(RuntimeError, "Failed to save document!")
+  document.save || raise("Failed to save document!")
   ```
 
 * <a name="no-multiline-ternary"></a>


### PR DESCRIPTION
The examples (including "good" ones) about [`and`, `or` keywords](https://github.com/bbatsov/ruby-style-guide#no-and-or-or) were raising exceptions in style that no longer matches the guide.

- [`raise` is preferred over `fail`](https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail) since #512, commit 3121628dd001b7d18a8985002144e76f99ef71d1.
- [Don't specify `RuntimeError` explicitly in the two argument version of `raise`.](https://github.com/bbatsov/ruby-style-guide#no-explicit-runtimeerror), since commit 8fad716ceb68b322c2e0869355564de5f47ff3d9

I was not sure if I should keep or drop parentheses in `raise('...')`.  Other places in guide use "pseudo-keyword" raise without parentheses, but the guide has no preference one way or another, and this is not about how to raise anyway.  IMHO they make reading the `raise(...) unless ...` example easier, so kept them.