### PR TITLE
Add missing newline for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,7 @@ Translations of the guide are available in the following languages:
     puts temperance.age
     system 'ls'
     ```
+
 * <a name="optional-arguments"></a>
     Define optional arguments at the end of the list of arguments.
     Ruby has some unexpected results when calling methods that have


### PR DESCRIPTION
While parsing this document, I discovered this is the one spot that does
not have a blank line before the next rule.